### PR TITLE
Add Clear Data Cache button to sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,7 +109,11 @@ with st.sidebar:
 
     run_btn = st.button("🚀 Run Forecast", type="primary",
                         use_container_width=True)
-
+    
+    st.sidebar.caption("Data cached for 1 hour")
+    if st.sidebar.button("🔄 Clear Data Cache"):
+       st.cache_data.clear()
+       st.rerun()
 # ═══════════════════════════════════════════════════════════════════════════════
 #  HEADER
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
Implemented the "Clear Data Cache" button in the sidebar as requested in issue #5.

## Changes
- Added a caption: "Data cached for 1 hour".
- Added a button: "🔄 Clear Data Cache".
- Linked the button to `st.cache_data.clear()` and `st.rerun()`.

## Status
- Code implemented in `app.py`.
- Manual verification: The button appears in the sidebar and triggers the app refresh when clicked.

Closes #5