### PR TITLE
test: add unit tests for compute_metrics()

### DIFF
--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -1,0 +1,27 @@
+from src.forecaster import compute_metrics
+
+class TestComputeMetrics:
+    def test_perfect_forecast(self):
+        result = compute_metrics([10, 20, 30], [10, 20, 30])
+        assert result["MAE"] == 0
+        assert result["RMSE"] == 0
+        assert result["MAPE"] == 0
+
+    def test_constant_offset(self):
+        result = compute_metrics([10, 20], [11, 21])
+        assert result["MAE"] == 1.0
+
+    def test_all_zeros_actual(self):
+        # should not raise ZeroDivisionError
+        result = compute_metrics([0, 0], [1, 2])
+        assert result is not None
+
+    def test_single_element(self):
+        result = compute_metrics([5], [5])
+        assert result["MAE"] == 0.0
+
+    def test_negative_values(self):
+        result = compute_metrics([-5, -10], [-4, -9])
+        assert result["MAE"] == 1.0
+        # actual = [-5, -10], predicted = [-4, -9] → handles negatives
+        


### PR DESCRIPTION
Closes #3

Added tests/test_forecaster.py covering compute_metrics():

- test_perfect_forecast: MAE = RMSE = MAPE = 0 when actual == predicted
- test_constant_offset: known MAE value with constant offset
- test_all_zeros_actual: no ZeroDivisionError when actuals are zero
- test_single_element: handles single element arrays
- test_negative_values: handles negative return values

Also added tests/__init__.py as required.